### PR TITLE
Extending API by implementing getStoredKeysMatching(prefix:biometricP…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ do {
 }
 ```
 
+Also, if you need to know what keys are already stored:
+
+```swift
+do {
+    let keys = try oktaStorage.getStoredKeys()
+} catch let error {
+    // Handle error
+}
+```
+
 ### Delete data from keychain
 
 ```swift
@@ -195,6 +205,21 @@ Retrieves the stored keychain item from the keychain. Additionally method expect
 DispatchQueue.global().async {
     do {
         let passwordData = try oktaStorage.getData("jdoe", prompt: “Please use Touch ID or Face ID to sign in”)
+    } catch let error {
+        // Handle error
+    }
+}
+```
+
+### `getStoredKeys(biometricPrompt:accessGroup:)`
+
+Retrieves previously stored keys from the keychain. Additionally method expects optional `prompt` message for the keychain item stored behind a biometric factor. Use `accessGroup` to access shared keychain items between apps.
+> * Note: Similarly to `getData` function, iOS will show native Touch ID or Face ID message view in case of biometrics enabled storage. It means that function may be blocked and wait for the user's action. It is advised to call  `getStoredKeys` function in a background thread.
+
+```swift
+DispatchQueue.global().async {
+    do {
+        let keys = try oktaStorage.getStoredKeys()
     } catch let error {
         // Handle error
     }


### PR DESCRIPTION
…rompt:accessGroup:) function

### Problem Analysis (Technical)
Currently, there are no possibility to access keychain by some key prefix and not the exact key.

### Solution (Technical)
Extending API by requesting Keychain items attributes and then filter keys by prefix: 
`getStoredKeysMatching(prefix:biometricPrompt:accessGroup:)`

The function replicates `hasPrefix()` behaviour for `String` from Swift's Foundation.
If this needs to be extended to accept some regex-backed search, please let me know.
"Has prefix" approach is initially chosen from a performance perspective

### Affected Components


### Steps to reproduce: N/A

Actual result:

Expected result:

### Tests
Added `testSetAndMultipleGetByPrefix()`