### PR TITLE
OKTA-789927: Move away from orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  general-platform-helpers: okta/general-platform-helpers@1.8
+  general-platform-helpers: okta/general-platform-helpers@1.9
   macos: circleci/macos@2
 
 executors:
@@ -37,12 +37,10 @@ jobs:
 workflows:
   semgrep:
     jobs:
-      - general-platform-helpers/job-semgrep-prepare:
-          name: semgrep-prepare
       - general-platform-helpers/job-semgrep-scan:
           name: semgrep-scan
-          requires:
-            - semgrep-prepare
+          context:
+            - static-analysis
 
   security-scan:
     jobs:
@@ -58,4 +56,6 @@ workflows:
       - snyk-scan:
           name: execute-snyk
           requires:
-            - prepare-snyk
+            - setup
+          context:
+            - static-analysis


### PR DESCRIPTION
This moves away from orb-defined jobs when running static analysis tooling.
